### PR TITLE
set boot frequency to 1.6G and correct distloss

### DIFF
--- a/romulus.xml
+++ b/romulus.xml
@@ -9240,7 +9240,7 @@
 	</attribute>
 	<attribute>
 		<id>BOOT_FREQ_MULT</id>
-		<default>120</default>
+		<default>96</default>
 	</attribute>
 	<attribute>
 		<id>BRANCH_PIBMEM_ADDR</id>
@@ -10670,15 +10670,15 @@
 	</attribute>
 	<attribute>
 		<id>PROC_R_DISTLOSS_VCS_UOHM</id>
-		<default>0</default>
+		<default>64</default>
 	</attribute>
 	<attribute>
 		<id>PROC_R_DISTLOSS_VDD_UOHM</id>
-		<default>150</default>
+		<default>10</default>
 	</attribute>
 	<attribute>
 		<id>PROC_R_DISTLOSS_VDN_UOHM</id>
-		<default>232</default>
+		<default>23</default>
 	</attribute>
 	<attribute>
 		<id>PROC_R_LOADLINE_VCS_UOHM</id>


### PR DESCRIPTION
1. set boot frequency to 1.6GHz (150---2.5, 144---2.4, 120---2.0, 96---1.6)
2. set distloss