### PR TITLE
Update AVS setting for VDD/VCS/VDN

### DIFF
--- a/romulus.xml
+++ b/romulus.xml
@@ -10900,11 +10900,11 @@
 	</attribute>
 	<attribute>
 		<id>VCS_AVSBUS_BUSNUM</id>
-		<default>1</default>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>VCS_AVSBUS_RAIL</id>
-		<default>0</default>
+		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>VCS_BOOT_VOLTAGE</id>
@@ -10924,7 +10924,7 @@
 	</attribute>
 	<attribute>
 		<id>VDD_AVSBUS_RAIL</id>
-		<default>1</default>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>VDD_BOOT_VOLTAGE</id>
@@ -10936,7 +10936,7 @@
 	</attribute>
 	<attribute>
 		<id>VDN_AVSBUS_RAIL</id>
-		<default>1</default>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>VDN_BOOT_VOLTAGE</id>


### PR DESCRIPTION
Correct the default setting for VDD, VCS and VDN AVS bus number and rail number as below:
1) VDD: AVS Bus 0, Rail 0
2) VCS: AVS Bus 0, Rail 1
3) VDN: AVS Bus1, Rail 0
4) VIO: AVS Bus1, Rail 1