### PR TITLE
Set 2400 for single drop, 2133 for dual drop as the max

### DIFF
--- a/romulus.xml
+++ b/romulus.xml
@@ -6059,7 +6059,7 @@
 	</attribute>
 	<attribute>
 		<id>MAX_ALLOWED_DIMM_FREQ</id>
-		<default>2400,2400,2400,2400,2400</default>
+		<default>2400,2400,2400,2133,2133</default>
 	</attribute>
 	<attribute>
 		<id>MAX_CHIPLETS_PER_PROC</id>
@@ -6421,7 +6421,7 @@
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_SUPPORTED_FREQ</id>
-		<default>0x74A,0x855,0,0</default>
+		<default>0x74A,0x855,0x960,0</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_TEMP_REFRESH_RANGE</id>


### PR DESCRIPTION
1). Enable 2400MHz for DIMM
2). Set 2400 for single drop, 2133 for dual drop as the max