### PR TITLE
Remove TPM_INFO attribute from node target

### DIFF
--- a/romulus.xml
+++ b/romulus.xml
@@ -7489,18 +7489,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>TPM_INFO</id>
-		<default>
-				<field><id>tpmEnabled</id><value></value></field>
-				<field><id>i2cMasterPath</id><value></value></field>
-				<field><id>port</id><value></value></field>
-				<field><id>devAddrLocality0</id><value></value></field>
-				<field><id>devAddrLocality4</id><value></value></field>
-				<field><id>engine</id><value></value></field>
-				<field><id>byteAddrOffset</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
 		<id>TYPE</id>
 		<default>NODE</default>
 	</attribute>


### PR DESCRIPTION
- Removed TPM_INFO attribute from node target, in preparation for removing it from attribute model
- TPM_INFO will ultimately be an attribute of a TPM target