### PR TITLE
Disable I2C engine2 port0 diag mode

### DIFF
--- a/romulus.xml
+++ b/romulus.xml
@@ -9895,6 +9895,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>DISABLE_I2C_ENGINE2_PORT0_DIAG_MODE</id>
+		<default>1</default>
+	</attribute>
+	<attribute>
 		<id>DEVICE_ID</id>
 		<default>0</default>
 	</attribute>


### PR DESCRIPTION
Disable i2c engine 2 port 0 diag mode to fix i2c error